### PR TITLE
[TMC-384] Feature: add side menu appear disappear event notifiers

### DIFF
--- a/Source/SideMenuController.swift
+++ b/Source/SideMenuController.swift
@@ -39,11 +39,16 @@ public extension SideMenuController {
         
         if !transitionInProgress {
             if !sidePanelVisible {
+                // Posting sideMenuWillAppear notification
+                NotificationCenter.default.post(name: SideMenuController.sideMenuWillAppear, object: nil)
                 
                 // Dismiss any showing keyboard in the centerViewController
                 self.centerViewController.view.endEditing(true)
                 
                 prepare(sidePanelForDisplay: true)
+            }else {
+                // Posting sideMenuWillDisappear notification
+                NotificationCenter.default.post(name: SideMenuController.sideMenuWillDisappear, object: nil)
             }
             
             animate(toReveal: !sidePanelVisible)
@@ -207,6 +212,9 @@ open class SideMenuController: UIViewController, UIGestureRecognizerDelegate {
     open override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return orientationLock
     }
+    
+    static let sideMenuWillAppear = Notification.Name("sideMenuWillAppear")
+    static let sideMenuWillDisappear = Notification.Name("sideMenuWillDisappear")
     
     // MARK:- View lifecycle -
     


### PR DESCRIPTION
This PR contains adding event notifiers to the `SideMenuController` that appear and disappear events when toggle.

Note: changes were introduced during Flutter-iOS integration [TMC-369](https://hectre.atlassian.net/browse/TMC-369)

[TMC-369]: https://hectre.atlassian.net/browse/TMC-369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ